### PR TITLE
chore(release): 更新发布工作流并添加赞助信息

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://afdian.com/a/ravenhogwarts"]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: 🐛 Bug Report | Bug 报告
+about: Create a report to help us improve | 创建一个 bug 报告以帮助我们改进
+title: '[Bug] '
+labels: bug
+assignees: ''
+---
+
+### Bug Description | 问题描述
+<!-- A clear and concise description of what the bug is | 清晰简洁地描述这个 bug 是什么 -->
+
+### Steps to Reproduce | 复现步骤
+<!-- Steps to reproduce the behavior | 详细描述如何复现这个问题 -->
+1. Go to '...' | 打开 '...'
+2. Click on '....' | 点击 '....'
+3. Scroll down to '....' | 滚动到 '....'
+4. See error | 看到错误
+
+### Expected Behavior | 预期行为
+<!-- A clear and concise description of what you expected to happen | 清晰简洁地描述你期望发生的事情 -->
+
+### Actual Behavior | 实际行为
+<!-- A clear and concise description of what actually happened | 清晰简洁地描述实际发生的事情 -->
+
+### Screenshots | 截图
+<!-- If applicable, add screenshots to help explain your problem | 如果适用，添加截图以帮助解释你的问题 -->
+
+### Environment | 环境信息
+- OS: [e.g., Windows 10, macOS 12.0] | 操作系统: [例如 Windows 10, macOS 12.0]
+- Obsidian Version: [e.g., 1.4.16] | Obsidian 版本: [例如 1.4.16]
+- Plugin Version: [e.g., 1.0.0] | 插件版本: [例如 1.0.0]
+
+### Other Plugins | 其他插件
+<!-- List enabled plugins, especially those that might be related to this issue | 列出已启用的其他插件，特别是可能与此问题相关的插件 -->
+
+### Additional Context | 附加信息
+<!-- Add any other context about the problem here | 添加关于这个问题的任何其他上下文信息 -->
+
+### Console Logs | 控制台日志
+<!-- If applicable, provide relevant console logs | 如果适用，请提供相关的控制台日志 -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+    - name: 💬 Discussion Forum | 讨论区
+      url: https://github.com/RavenHogWarts/obsidian-custom-icons/discussions
+      about: Please ask general questions here | 请在这里提出一般性问题

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: 💡 Feature Request | 功能请求
+about: Suggest an idea for this project | 为这个项目提出一个想法
+title: '[Feature] '
+labels: enhancement
+assignees: ''
+---
+
+### Feature Description | 功能描述
+<!-- A clear and concise description of the feature you want | 清晰简洁地描述你想要的功能 -->
+
+### Use Case | 使用场景
+<!-- Describe the context where this feature would be used and what problem it solves | 描述这个功能会在什么场景下使用，解决什么问题 -->
+
+### Proposed Solution | 期望的解决方案
+<!-- Describe how you'd like this feature to work | 描述你希望这个功能如何工作 -->
+
+### Alternative Solutions | 替代方案
+<!-- Describe any alternative solutions or features you've considered | 描述你考虑过的替代解决方案或功能 -->
+
+### Additional Context | 其他上下文
+<!-- Add any other context or screenshots about the feature request here | 添加关于功能请求的其他上下文或截图 -->
+
+### Implementation Suggestions | 实现建议
+<!-- If you have specific ideas about how to implement this feature, describe them here | 如果你有关于如何实现这个功能的具体想法，请在这里描述 -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,88 +1,236 @@
 name: Release Obsidian plugin
 
 on:
-  push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - "*" # Push events to matching any tag format, i.e. 1.0, 20.15.10
+    push:
+        tags:
+            - "[0-9]+.[0-9]+.[0-9]+*" # 匹配类似 1.0.0 或 1.0.0-beta.1 的格式
+
+permissions:
+    contents: write
 
 env:
-  PLUGIN_NAME: obsidian-custom-icons
+    PLUGIN_ID: custom-sidebar-icons # 插件ID
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+    build:
+        runs-on: ubuntu-22.04
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: "16.x" # You might need to adjust this value to your own version
-      - name: Build
-        id: build
-        run: |
-          npm install -g yarn
-          yarn
-          yarn run build --if-present
-          mkdir ${{ env.PLUGIN_NAME }}
-          cp main.js manifest.json styles.css ${{ env.PLUGIN_NAME }}
-          zip -r ${{ env.PLUGIN_NAME }}.zip ${{ env.PLUGIN_NAME }}
-          ls
-          echo "::set-output name=tag_name::$(git tag --sort version:refname | tail -n 1)"
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0 # 获取完整的git历史
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ github.ref }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: ${{ contains(github.ref, 'b') && true || false }}
+            - name: Use Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version: "18.x"
 
-      - name: Upload zip file
-        id: upload-zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./${{ env.PLUGIN_NAME }}.zip
-          asset_name: ${{ env.PLUGIN_NAME }}-${{ steps.build.outputs.tag_name }}.zip
-          asset_content_type: application/zip
+            - name: Prepare manifest
+              id: prepare_manifest
+              run: |
+                  if [[ ${{ github.ref }} == *"beta"* ]]; then
+                    cp manifest-beta.json manifest.json
+                  fi
 
-      - name: Upload main.js
-        id: upload-main
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./main.js
-          asset_name: main.js
-          asset_content_type: text/javascript
+            - name: Build
+              id: build
+              run: |
+                  npm install -g yarn
+                  yarn
+                  yarn run build --if-present
+                  mkdir ${{ env.PLUGIN_ID }}
+                  cp main.js manifest.json styles.css ${{ env.PLUGIN_ID }}
+                  zip -r ${{ env.PLUGIN_ID }}.zip ${{ env.PLUGIN_ID }}
+                  ls
+                  echo "tag_name=$(git tag --sort version:refname | tail -n 1)" >> $GITHUB_OUTPUT
 
-      - name: Upload manifest.json
-        id: upload-manifest
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./manifest.json
-          asset_name: manifest.json
-          asset_content_type: application/json
+            - name: Generate Changelog
+              id: changelog
+              run: |
+                  # 初始化 changelog 文件
+                  CHANGELOG_EN="CHANGELOG.md"
+                  CHANGELOG_ZH="CHANGELOG-zh.md"
+                  TEMP_CHANGELOG="temp_changelog.md"
+                  EN_TEMP_CHANGELOG="en_temp_changelog.md"
+                  ZH_TEMP_CHANGELOG="zh_temp_changelog.md"
 
-      - name: Upload styles.css
-        id: upload-styles
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./styles.css
-          asset_name: styles.css
-          asset_content_type: text/css
+                  # 获取当前版本号（从 git tag）
+                  CURRENT_VERSION=$(git tag --sort version:refname | tail -n 1)
+                  echo "Current version: $CURRENT_VERSION"
+
+                  # 确保 PLUGIN_ID 变量可用
+                  PLUGIN_ID="${{ env.PLUGIN_ID }}"
+                  echo "Using plugin name: $PLUGIN_ID"
+
+                  # 使用 awk 提取特定版本的 changelog 内容
+                  extract_changelog() {
+                    local changelog_file=$1
+                    local output_file=$2
+                    local is_chinese=$3
+                    local target_version=$4
+                    
+                    > "$output_file"  # 初始化空文件
+                    
+                    # 确定版本的标题级别 (# 或 ##)
+                    # 分解版本号，检查是否为小版本
+                    IFS='.' read -r major minor patch <<< "$target_version"
+                    # 如果patch不是0，那么是小版本，使用二级标题 (##)
+                    if [[ -n "$patch" && "$patch" != "0" ]]; then
+                      local title_level="##"
+                    else
+                      # 大版本或次版本，使用一级标题 (#)
+                      local title_level="#"
+                    fi
+                    
+                    echo "Looking for version $target_version with title level: $title_level"
+                    
+                    # 使用 awk 提取目标版本的内容到临时文件
+                    awk -v version="$target_version" -v level="$title_level" '
+                    BEGIN { found = 0; printing = 0; }
+                    
+                    # 当找到目标版本标题时
+                    $0 ~ "^" level " +\\[" version "\\]" { 
+                      found = 1; 
+                      printing = 1; 
+                      next;  # 跳过版本标题行
+                    }
+                    
+                    # 当找到下一个版本标题时停止打印
+                    printing && $0 ~ "^#+ +\\[" { 
+                      printing = 0; 
+                    }
+                    
+                    # 打印匹配到的内容
+                    printing { 
+                      print; 
+                    }
+                    
+                    # 文件结束时，如果没有找到目标版本，输出警告
+                    END { 
+                      if (!found) {
+                        print "Warning: Version " version " not found with title level " level > "/dev/stderr";
+                        exit 1;
+                      }
+                    }' "$changelog_file" > "temp_version_content.md"
+                    
+                    # 检查提取内容
+                    if [ ! -s "temp_version_content.md" ]; then
+                      echo "Warning: No content found for version $target_version in $changelog_file" >&2
+                      if [ "$is_chinese" = true ]; then
+                        echo -e "## 更新内容\n\n该版本 $target_version 没有找到更新日志。\n" >> "$output_file"
+                      else
+                        echo -e "## Changes\n\nNo changelog found for version $target_version.\n" >> "$output_file"
+                      fi
+                    else
+                      echo "Successfully extracted changelog for version $target_version"
+                      if [ "$is_chinese" = true ]; then
+                        echo -e "## 更新内容\n" >> "$output_file"
+                      else
+                        echo -e "## Changes\n" >> "$output_file"
+                      fi
+                      cat "temp_version_content.md" >> "$output_file"
+                    fi
+                    
+                    # 添加安装说明
+                    if [ "$is_chinese" = true ]; then
+                      echo -e "\n## 如何安装\n" >> "$output_file"
+                      echo -e "1. 下载 \`$PLUGIN_ID.zip\` 压缩文件" >> "$output_file"
+                      echo -e "2. 解压到你的 Obsidian 库的插件文件夹内: \`<vault>/.obsidian/plugins/$PLUGIN_ID/\`" >> "$output_file"
+                      echo -e "3. 重启 Obsidian" >> "$output_file"
+                      echo -e "4. 在设置中启用 **$PLUGIN_ID** 插件" >> "$output_file"
+                    else
+                      echo -e "\n## Installation\n" >> "$output_file"
+                      echo -e "1. Download \`$PLUGIN_ID.zip\`" >> "$output_file"
+                      echo -e "2. Unzip it to your Obsidian vault's plugins folder: \`<vault>/.obsidian/plugins/$PLUGIN_ID/\`" >> "$output_file"
+                      echo -e "3. Reload Obsidian" >> "$output_file"
+                      echo -e "4. Enable **$PLUGIN_ID** plugin in settings" >> "$output_file"
+                    fi
+                  }
+
+                  # 处理英文 changelog
+                  if [ -f "$CHANGELOG_EN" ]; then
+                    extract_changelog "$CHANGELOG_EN" "$EN_TEMP_CHANGELOG" false "$CURRENT_VERSION"
+                  else
+                    echo "英文 changelog 文件未找到。使用备用方案。"
+                    echo -e "## Changes\n\nNo changelog available.\n\n## Installation\n\n1. Download \`$PLUGIN_ID.zip\`\n2. Unzip it to your Obsidian vault's plugins folder: \`<vault>/.obsidian/plugins/$PLUGIN_ID/\`\n3. Reload Obsidian\n4. Enable **$PLUGIN_ID** plugin in settings" > "$EN_TEMP_CHANGELOG"
+                  fi
+
+                  # 处理中文 changelog
+                  if [ -f "$CHANGELOG_ZH" ]; then
+                    extract_changelog "$CHANGELOG_ZH" "$ZH_TEMP_CHANGELOG" true "$CURRENT_VERSION"
+                    
+                    # 合并两个 changelogs，保持良好的格式
+                    echo -e "# English Changelog\n" > "$TEMP_CHANGELOG"
+                    cat "$EN_TEMP_CHANGELOG" >> "$TEMP_CHANGELOG"
+                    echo -e "\n\n---\n\n# 中文更新日志\n" >> "$TEMP_CHANGELOG"
+                    cat "$ZH_TEMP_CHANGELOG" >> "$TEMP_CHANGELOG"
+                  else
+                    # 如果没有中文 changelog，只使用英文版本
+                    cp "$EN_TEMP_CHANGELOG" "$TEMP_CHANGELOG"
+                  fi
+
+                  # 输出 changelog 给 GitHub Actions
+                  echo "changelog<<EOF" >> $GITHUB_OUTPUT
+                  cat "$TEMP_CHANGELOG" >> $GITHUB_OUTPUT
+                  echo "EOF" >> $GITHUB_OUTPUT
+
+            - name: Create Release
+              id: create_release
+              uses: actions/create-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  tag_name: ${{ github.ref }}
+                  release_name: ${{ github.ref }}
+                  draft: false
+                  prerelease: ${{ contains(github.ref, 'beta') }}
+                  body: |
+                      ${{ contains(github.ref, 'beta') && '🚧 This is a beta release' || '🎉 This is a stable release' }}
+
+                      **Version:** ${{ github.ref_name }}
+
+                      ${{ steps.changelog.outputs.changelog }}
+
+            - name: Upload zip file
+              id: upload-zip
+              uses: actions/upload-release-asset@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  upload_url: ${{ steps.create_release.outputs.upload_url }}
+                  asset_path: ./${{ env.PLUGIN_ID }}.zip
+                  asset_name: ${{ env.PLUGIN_ID }}.zip
+                  asset_content_type: application/zip
+
+            - name: Upload main.js
+              id: upload-main
+              uses: actions/upload-release-asset@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  upload_url: ${{ steps.create_release.outputs.upload_url }}
+                  asset_path: ./main.js
+                  asset_name: main.js
+                  asset_content_type: text/javascript
+
+            - name: Upload manifest.json
+              id: upload-manifest
+              uses: actions/upload-release-asset@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  upload_url: ${{ steps.create_release.outputs.upload_url }}
+                  asset_path: ./manifest.json
+                  asset_name: manifest.json
+                  asset_content_type: application/json
+
+            - name: Upload styles.css
+              id: upload-styles
+              uses: actions/upload-release-asset@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  upload_url: ${{ steps.create_release.outputs.upload_url }}
+                  asset_path: ./styles.css
+                  asset_name: styles.css
+                  asset_content_type: text/css


### PR DESCRIPTION
更新 GitHub Actions 发布工作流以提高兼容性和自动化，并添加项目赞助链接。
主要改动：
- 将发布触发与标签格式改为匹配语义化版本号（如 1.0.0），减少误触发。
- 升级 runner 和 Actions 版本（ubuntu-22.04、checkout@v4、setup-node@v3）
  以利用更稳定的运行环境和新版 Node 支持。
- 增强构建步骤：
  - 使用 PLUGIN_ID 替代旧变量名，统一构件目录与 zip 命名。
  - 在构建前根据分支/标签选择 manifest（支持 beta 发行）。
  - 使用 GITHUB_OUTPUT 输出 tag_name，兼容新版 Actions 输出方式。
- 新增生成 Changelog 的占位脚本，准备自动化发布说明生成。
- 在仓库根添加 FUNDING 配置以支持 AfDian 赞助链接。

变更原因：
- 提升发布流程的可靠性、兼容性和可维护性，便于自动化版本管理和多通道发布。
- 增加赞助渠道，支持项目持续维护。