### PR TITLE
feat: 抽离默认图标设置到独立分组

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -5,7 +5,10 @@ const translations: BaseMessage = {
 	settings: {
 		communityPlugin: {
 			name: "Community Plugins",
-			desc: "Add custom icons for community plugins settings.",
+			default: {
+				name: "Default Icon",
+				desc: "Set a default icon for community plugins without icons",
+			},
 			pluginList: {
 				name: "Plugin List",
 				desc: "Add custom icons for community plugins without icons (Fix for Obsidian v1.11.0)",

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -4,7 +4,10 @@ const translations: BaseMessage = {
 	settings: {
 		communityPlugin: {
 			name: "第三方外掛程式",
-			desc: "為第三方外掛程式設置中添加自訂圖示。",
+			default: {
+				name: "預設圖示",
+				desc: "為沒有圖示的第三方外掛程式設定添加預設圖示",
+			},
 			pluginList: {
 				name: "外掛程式列表",
 				desc: "為沒有圖示的第三方外掛程式添加自訂圖示（修復 Obsidian v1.11.0）",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -4,7 +4,10 @@ const translations: BaseMessage = {
 	settings: {
 		communityPlugin: {
 			name: "第三方插件",
-			desc: "为第三方插件设置中添加自定义图标。",
+			default: {
+				name: "默认图标",
+				desc: "为没有图标的第三方插件设置添加默认图标",
+			},
 			pluginList: {
 				name: "插件列表",
 				desc: "为没有图标的第三方插件添加自定义图标（修复 Obsidian v1.11.0）",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -11,7 +11,7 @@ export const SupportedLocales: Record<string, BaseMessage> = {
 
 interface IBaseSettingsItem {
 	name: string;
-	desc: string;
+	desc?: string;
 }
 export type SettingsItem<T = Record<string, never>> = IBaseSettingsItem & T;
 
@@ -19,6 +19,7 @@ export type SettingsItem<T = Record<string, never>> = IBaseSettingsItem & T;
 export type BaseMessage = {
 	settings: {
 		communityPlugin: SettingsItem<{
+			default: IBaseSettingsItem;
 			pluginList: IBaseSettingsItem;
 		}>;
 	};

--- a/src/settings/tabs/CommunityPlugin.tsx
+++ b/src/settings/tabs/CommunityPlugin.tsx
@@ -51,34 +51,37 @@ export const CommunityPlugin: FC = () => {
 	return (
 		<>
 			{/* 默认图标设置 */}
-			<SettingItem
-				name={t("settings.communityPlugin.name")}
-				desc={t("settings.communityPlugin.desc")}
-				control={
-					<>
-						<ExtraButton
-							icon="reset"
-							tooltip="重置为默认"
-							onClick={() => {
-								settingsStore.updateSettingByPath(
-									"communityPlugins.default",
-									DEFAULT_SETTINGS.communityPlugins.default
-								);
-							}}
-						/>
-						<IconPicker
-							app={settingsStore.app}
-							value={settings.communityPlugins.default.icon}
-							onChange={(value) => {
-								settingsStore.updateSettingByPath(
-									"communityPlugins.default.icon",
-									value
-								);
-							}}
-						/>
-					</>
-				}
-			/>
+			<SettingGroup>
+				<SettingItem
+					name={t("settings.communityPlugin.default.name")}
+					desc={t("settings.communityPlugin.default.desc")}
+					control={
+						<>
+							<ExtraButton
+								icon="reset"
+								tooltip="重置为默认"
+								onClick={() => {
+									settingsStore.updateSettingByPath(
+										"communityPlugins.default",
+										DEFAULT_SETTINGS.communityPlugins
+											.default
+									);
+								}}
+							/>
+							<IconPicker
+								app={settingsStore.app}
+								value={settings.communityPlugins.default.icon}
+								onChange={(value) => {
+									settingsStore.updateSettingByPath(
+										"communityPlugins.default.icon",
+										value
+									);
+								}}
+							/>
+						</>
+					}
+				/>
+			</SettingGroup>
 
 			{/* 插件列表分组 */}
 			<SettingGroup title={t("settings.communityPlugin.pluginList.name")}>


### PR DESCRIPTION
将社区插件设置中的“默认图标”项改为可选描述并移动到独立的设置分组，
并为 i18n 补充对应的默认项文本（中/繁/英）。这样做有以下目的：
- 将原本作为 communityPlugin.desc 的描述改为可选字段，增加灵活性以适应
  嵌套子项（比如 default）的存在。
- 在界面上把默认图标设置从通用项拆分为单独的 SettingGroup，增强可读性
  和可维护性，并修正更新默认设置路径时引用的常量位置。
- 为多语言资源添加 settings.communityPlugin.default 的 name 和 desc，
  确保不同语言下该分组显示正确的标题和说明。

这些改动主要是为了改善设置结构的语义性和 UI 可用性，便于后续扩展
更多子设置项。