### PR TITLE
feat(settings): 添加社区外掛启用开关及异步设置更新

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -4,14 +4,18 @@ import { BaseMessage } from "@src/i18n/types";
 const translations: BaseMessage = {
 	settings: {
 		communityPlugin: {
-			name: "Community Plugins",
+			name: "Community plugins",
+			enable: {
+				name: "Enable feature",
+				desc: "Add icons for community plugins without icons",
+			},
 			default: {
-				name: "Default Icon",
+				name: "Default icon",
 				desc: "Set a default icon for community plugins without icons",
 			},
 			pluginList: {
-				name: "Plugin List",
-				desc: "Add custom icons for community plugins without icons (Fix for Obsidian v1.11.0)",
+				name: "Plugin list",
+				desc: "Add custom icons for community plugins without icons (fix for Obsidian v1.11.0)",
 			},
 		},
 	},

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -4,6 +4,10 @@ const translations: BaseMessage = {
 	settings: {
 		communityPlugin: {
 			name: "第三方外掛程式",
+			enable: {
+				name: "啟用功能",
+				desc: "為沒有圖示的第三方外掛程式設定添加圖示",
+			},
 			default: {
 				name: "預設圖示",
 				desc: "為沒有圖示的第三方外掛程式設定添加預設圖示",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -4,6 +4,10 @@ const translations: BaseMessage = {
 	settings: {
 		communityPlugin: {
 			name: "第三方插件",
+			enable: {
+				name: "启用功能",
+				desc: "为没有图标的第三方插件设置添加图标",
+			},
 			default: {
 				name: "默认图标",
 				desc: "为没有图标的第三方插件设置添加默认图标",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -19,6 +19,7 @@ export type SettingsItem<T = Record<string, never>> = IBaseSettingsItem & T;
 export type BaseMessage = {
 	settings: {
 		communityPlugin: SettingsItem<{
+			enable: IBaseSettingsItem;
 			default: IBaseSettingsItem;
 			pluginList: IBaseSettingsItem;
 		}>;

--- a/src/settings/tabs/CommunityPlugin.tsx
+++ b/src/settings/tabs/CommunityPlugin.tsx
@@ -3,6 +3,7 @@ import {
 	ExtraButton,
 	SettingGroup,
 	SettingItem,
+	Toggle,
 } from "@src/components/obsidian-setting";
 import usePluginSettings from "@src/hooks/usePluginSettings";
 import useSettingsStore from "@src/hooks/useSettingsStore";
@@ -53,6 +54,23 @@ export const CommunityPlugin: FC = () => {
 			{/* 默认图标设置 */}
 			<SettingGroup>
 				<SettingItem
+					name={t("settings.communityPlugin.enable.name")}
+					desc={t("settings.communityPlugin.enable.desc")}
+					control={
+						<>
+							<Toggle
+								value={settings.communityPlugins.enable}
+								onChange={async (value) => {
+									await settingsStore.updateSettingByPath(
+										"communityPlugins.enable",
+										value
+									);
+								}}
+							/>
+						</>
+					}
+				/>
+				<SettingItem
 					name={t("settings.communityPlugin.default.name")}
 					desc={t("settings.communityPlugin.default.desc")}
 					control={
@@ -60,8 +78,8 @@ export const CommunityPlugin: FC = () => {
 							<ExtraButton
 								icon="reset"
 								tooltip="重置为默认"
-								onClick={() => {
-									settingsStore.updateSettingByPath(
+								onClick={async () => {
+									await settingsStore.updateSettingByPath(
 										"communityPlugins.default",
 										DEFAULT_SETTINGS.communityPlugins
 											.default
@@ -71,8 +89,8 @@ export const CommunityPlugin: FC = () => {
 							<IconPicker
 								app={settingsStore.app}
 								value={settings.communityPlugins.default.icon}
-								onChange={(value) => {
-									settingsStore.updateSettingByPath(
+								onChange={async (value) => {
+									await settingsStore.updateSettingByPath(
 										"communityPlugins.default.icon",
 										value
 									);
@@ -98,8 +116,8 @@ export const CommunityPlugin: FC = () => {
 									<ExtraButton
 										icon="reset"
 										tooltip="重置图标"
-										onClick={() => {
-											settingsStore.deleteSettingByPath(
+										onClick={async () => {
+											await settingsStore.deleteSettingByPath(
 												`communityPlugins.data.${plugin.id}`
 											);
 										}}
@@ -111,16 +129,16 @@ export const CommunityPlugin: FC = () => {
 											settings.communityPlugins.default
 												.icon
 										}
-										onChange={(value) => {
-											settingsStore.updateSettingByPath(
+										onChange={async (value) => {
+											await settingsStore.updateSettingByPath(
 												`communityPlugins.data.${plugin.id}.id`,
 												plugin.id
 											);
-											settingsStore.updateSettingByPath(
+											await settingsStore.updateSettingByPath(
 												`communityPlugins.data.${plugin.id}.icon`,
 												value
 											);
-											settingsStore.updateSettingByPath(
+											await settingsStore.updateSettingByPath(
 												`communityPlugins.data.${plugin.id}.type`,
 												settings.communityPlugins
 													.default.type

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,6 @@
 export interface IPluginSettings {
 	communityPlugins: {
+		enable: boolean;
 		default: ICommunityPluginIcon;
 		data: Record<string, ICommunityPluginIcon>;
 	};
@@ -17,6 +18,7 @@ interface IIcon {
 
 export const DEFAULT_SETTINGS: IPluginSettings = {
 	communityPlugins: {
+		enable: false,
 		default: { id: "", icon: "puzzle", type: "lucide" },
 		data: {},
 	},


### PR DESCRIPTION
- 在 IPluginSettings 与 DEFAULT_SETTINGS 中新增 communityPlugins.enable 字段，默认 false
- 在 i18n/types.ts 与 locales 中为 settings.communityPlugin 添加 enable 的 name 与 desc（zh / zh-TW / en）
- CommunityPlugin 设置页新增 Toggle 启用项并绑定 settings.communityPlugins.enable
- 将 updateSettingByPath / deleteSettingByPath / onChange 等设置操作改为异步 await 调用，确保持久化先完成，避免竞态与 UI 不一致