### PR TITLE
fix(setting): 移除 Obsidian 设置项的 DOM 元素

### DIFF
--- a/src/components/obsidian-setting/SettingItem.tsx
+++ b/src/components/obsidian-setting/SettingItem.tsx
@@ -119,6 +119,7 @@ export const SettingItem: FC<SettingItemProps> = ({
 	useEffect(() => {
 		return () => {
 			setting.clear();
+			setting.settingEl.remove(); // 确保 DOM 元素被移除
 		};
 	}, [setting]);
 


### PR DESCRIPTION
在组件卸载时不仅清理 setting 状态，还显式调用
setting.settingEl.remove() 以确保对应的 DOM 元素从文档中
被移除。这样做是为了避免残留的 DOM 节点导致内存泄漏或
重复渲染问题，尤其在频繁创建销毁设置项的场景下能保持
界面和内存的整洁。