### PR TITLE
feat: 支持 lucide-react 图标并改进渲染逻辑

### DIFF
--- a/src/components/icon-picker/IconPicker.tsx
+++ b/src/components/icon-picker/IconPicker.tsx
@@ -1,11 +1,6 @@
-import {
-	App,
-	FuzzyMatch,
-	FuzzySuggestModal,
-	getIconIds,
-	IconName,
-	setIcon,
-} from "obsidian";
+import { getLucideIconNames } from "@src/util/getLucideIcons";
+import setIcon from "@src/util/setIcon";
+import { App, FuzzyMatch, FuzzySuggestModal } from "obsidian";
 import * as React from "react";
 import "./IconPicker.css";
 
@@ -33,7 +28,7 @@ export const IconPicker: React.FC<IconPickerProps> = ({
 
 	React.useEffect(() => {
 		if (buttonRef.current) {
-			setIcon(buttonRef.current, selectedIcon);
+			setIcon(buttonRef.current, "lucide", selectedIcon);
 		}
 	}, [selectedIcon]);
 
@@ -51,7 +46,7 @@ export const IconPicker: React.FC<IconPickerProps> = ({
 	);
 };
 
-class IconSelector extends FuzzySuggestModal<IconName> {
+class IconSelector extends FuzzySuggestModal<string> {
 	private callback: (icon: string) => void;
 
 	constructor(app: App, callback: (icon: string) => void) {
@@ -64,22 +59,26 @@ class IconSelector extends FuzzySuggestModal<IconName> {
 		]);
 	}
 
-	getItems(): IconName[] {
-		return getIconIds().map((id) => id.replace("lucide-", ""));
+	getItems(): string[] {
+		const icons = getLucideIconNames();
+		return icons;
 	}
 
-	getItemText(icon: IconName): string {
+	getItemText(icon: string): string {
 		return icon;
 	}
 
-	renderSuggestion(item: FuzzyMatch<IconName>, el: HTMLElement) {
-		super.renderSuggestion(item, el);
+	renderSuggestion(item: FuzzyMatch<string>, el: HTMLElement) {
 		el.addClass("CI__icon-suggestion");
-		setIcon(el, item.item);
+
+		// 将图标作为子元素追加，而不是替换整个元素内容
+		setIcon(el, "lucide", item.item, { append: true });
+
+		// 创建文本容器（与图标 SVG 同级）
 		el.createSpan({ text: item.item });
 	}
 
-	onChooseItem(item: IconName, evt: MouseEvent | KeyboardEvent): void {
+	onChooseItem(item: string, evt: MouseEvent | KeyboardEvent): void {
 		this.callback(item);
 	}
 }

--- a/src/util/getLucideIcons.ts
+++ b/src/util/getLucideIcons.ts
@@ -1,0 +1,80 @@
+import * as icons from "lucide-react";
+
+/**
+ * 获取所有可用的 Lucide 图标名称列表
+ * 从 lucide-react 包中提取所有图标组件名称
+ */
+export function getLucideIconNames(): string[] {
+	const iconNames: string[] = [];
+
+	for (const key in icons) {
+		const value = icons[key as keyof typeof icons];
+
+		// lucide-react 导出三种格式：
+		// 1. PascalCase (如 Apple)
+		// 2. PascalCaseIcon (如 AppleIcon)
+		// 3. LucidePascalCase (如 LucideApple)
+		// 我们只使用第一种 PascalCase 格式
+		if (
+			key !== "default" &&
+			key !== "createLucideIcon" &&
+			!key.startsWith("Lucide") && // 过滤掉 Lucide 前缀的版本
+			!key.endsWith("Icon") && // 过滤掉 Icon 后缀的版本
+			/^[A-Z]/.test(key) &&
+			value !== undefined
+		) {
+			// 将 PascalCase 转换为 kebab-case
+			const iconName = key
+				.replace(/([A-Z])/g, "-$1")
+				.toLowerCase()
+				.slice(1);
+
+			// 过滤掉空字符串
+			if (iconName) {
+				iconNames.push(iconName);
+			}
+		}
+	}
+
+	return iconNames.sort();
+}
+
+/**
+ * 将 kebab-case 图标名称转换为 PascalCase 组件名称
+ * 例如：arrow-right -> ArrowRight
+ */
+export function iconNameToComponentName(iconName: string): string {
+	const pascalCase = iconName
+		.split("-")
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join("");
+
+	return pascalCase;
+}
+
+/**
+ * 获取 Lucide 图标组件
+ * @param iconName - kebab-case 格式的图标名称（例如：'arrow-right'）
+ * @returns 图标组件或 undefined
+ */
+export function getLucideIcon(
+	iconName: string
+): React.ComponentType<any> | undefined {
+	if (!iconName) {
+		console.warn("getLucideIcon: iconName is empty");
+		return undefined;
+	}
+
+	const componentName = iconNameToComponentName(iconName);
+
+	// 直接获取 PascalCase 格式的图标组件
+	const component = icons[componentName as keyof typeof icons] as
+		| React.ComponentType<any>
+		| undefined;
+
+	if (!component) {
+		console.warn(`Lucide icon "${iconName}" (${componentName}) not found`);
+	}
+
+	return component;
+}

--- a/src/util/setIcon.ts
+++ b/src/util/setIcon.ts
@@ -1,9 +1,94 @@
 import { IconType } from "@src/types/types";
-import { setIcon } from "obsidian";
+import * as React from "react";
+import { createRoot, Root } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { getLucideIcon } from "./getLucideIcons";
 
-export default function (el: HTMLElement, iconType: IconType, icon: string) {
-	// 目前只支持 obsidian 内置的 lucide (v0.446.0) 图标
+// 存储已创建的 React root，用于清理
+const rootMap = new WeakMap<HTMLElement, Root>();
+
+/**
+ * 在指定元素中渲染图标
+ * @param el - 目标元素
+ * @param iconType - 图标类型
+ * @param icon - 图标名称
+ * @param options - 配置选项
+ * @param options.append - 如果为 true，将图标作为子元素追加；否则替换元素内容
+ * @returns 渲染图标的容器元素（仅当 append 为 true 时）
+ */
+export default function (
+	el: HTMLElement,
+	iconType: IconType,
+	icon: string,
+	options?: { append?: boolean }
+): HTMLElement | void {
+	// 支持 lucide-react (v0.561.0) 图标
 	if (iconType === "lucide") {
-		setIcon(el, icon);
+		const IconComponent = getLucideIcon(icon);
+
+		if (IconComponent) {
+			try {
+				if (options?.append) {
+					// 使用 renderToStaticMarkup 将 React 组件渲染为静态 HTML 字符串
+					const svgString = renderToStaticMarkup(
+						React.createElement(IconComponent, {
+							size: 16,
+							strokeWidth: 2,
+							className: "lucide-icon",
+						})
+					);
+
+					// 创建一个临时容器来解析 HTML
+					const tempContainer = document.createElement("div");
+					tempContainer.innerHTML = svgString;
+
+					// 获取 SVG 元素并直接插入到目标元素中
+					const svgElement = tempContainer.firstChild as SVGElement;
+					if (svgElement) {
+						el.appendChild(svgElement);
+						return svgElement as any;
+					}
+				} else {
+					// 替换元素内容（原有逻辑，使用 React root）
+					const existingRoot = rootMap.get(el);
+					if (existingRoot) {
+						existingRoot.unmount();
+						rootMap.delete(el);
+					}
+					el.empty();
+
+					const root = createRoot(el);
+					rootMap.set(el, root);
+
+					root.render(
+						React.createElement(IconComponent, {
+							size: 16,
+							strokeWidth: 2,
+							className: "lucide-icon",
+						})
+					);
+				}
+			} catch (error) {
+				console.error(`Error rendering Lucide icon "${icon}":`, error);
+				if (!options?.append) {
+					const root = rootMap.get(el);
+					if (root) {
+						root.unmount();
+						rootMap.delete(el);
+					}
+				}
+			}
+		} else {
+			console.warn(`Lucide icon "${icon}" not found`);
+		}
 	}
+}
+
+export function cleanupIcon(el: HTMLElement) {
+	const existingRoot = rootMap.get(el);
+	if (existingRoot) {
+		existingRoot.unmount();
+		rootMap.delete(el);
+	}
+	el.empty();
 }


### PR DESCRIPTION
在图标选择与渲染中引入对 lucide-react 的支持，重构相关工具以
便更灵活且更可靠地处理图标显示。

主要改动：
- 将 IconPicker 中对图标来源与类型的调用改为使用本地工具
  getLucideIconNames 与 setIcon，类型从 IconName 改为通用 string，
  并在渲染与设置图标时显式传入 "lucide" 类型。
- 重写 util/setIcon.ts：
  - 使用 lucide-react 的组件进行渲染，支持两种模式：
    - append: 将渲染得到的 SVG 作为子元素追加到目标元素（不破
      坏原有 DOM），通过 renderToStaticMarkup 解析并插入 SVG。
    - replace（默认）: 使用 react-dom 的 createRoot 将图标渲染到
      目标元素，并在重新渲染前卸载已有 root，避免内存泄漏。
  - 使用 WeakMap 跟踪已创建的 React roots，并提供 cleanupIcon
    用于清理。
  - 增加错误与未找到图标的日志，提升鲁棒性。
- 新增 util/getLucideIcons.ts：从 lucide-react 中提取可用的图标名
  单一来源，供选择器展示列表。
- 调整 IconSelector 的渲染细节：
  - 在 suggestion 中将图标作为与文本同级的子元素追加（append）
    而非替换整个元素内容，避免丢失样式或事件绑定。
  - 统一类型签名，简化回调和选择逻辑。

为什么做这些改动：
- 迁移到 lucide-react 以使用更现代、可控的图标组件，方便定制
  样式与属性（如 size、strokeWidth）。
- append 与 replace 两种渲染方式提供更灵活的使用场景，避免在
  列表渲染时破坏外层元素结构或造成多次重建问题。
- 通过集中获取图标名及统一渲染逻辑，提高可维护性并减少重复
  代码与潜在内存泄漏。