### PR TITLE
refactor: 调整插件加载顺序和初始化逻辑

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,14 +11,11 @@ export default class CIPlugin extends Plugin {
 	readonly iconManager = new IconManager(this.app);
 
 	async onload() {
-		await this.settingsStore.loadSettings();
-
-		// 注册所有图标处理器
 		this.registerIconHandlers();
 
+		await this.settingsStore.loadSettings();
+
 		this.app.workspace.onLayoutReady(() => {
-			// 初始化并应用所有图标处理器
-			this.iconManager.updateSettings(this.settings);
 			this.iconManager.applyAll();
 		});
 
@@ -26,7 +23,6 @@ export default class CIPlugin extends Plugin {
 	}
 
 	onunload() {
-		// 清理所有图标处理器
 		this.iconManager.cleanupAll();
 	}
 


### PR DESCRIPTION
将设置加载移动到注册图标处理器之后，调整初始化流程以保证
注册完成后再加载设置，从而让图标处理器在应用设置前已经就绪。
在 workspace 就绪时直接调用 iconManager.applyAll() 以应用当前配
置，并在卸载时保留 cleanupAll() 调用。此修改改善了初始化顺序，
避免在处理器未注册时加载设置导致的竞态或无效初始化。