### PR TITLE
feat: 避免重复渲染并缓存图标状态

### DIFF
--- a/src/util/addIconToPluginNavItem.ts
+++ b/src/util/addIconToPluginNavItem.ts
@@ -28,8 +28,23 @@ export default function (
 		} else {
 			navItemEl.appendChild(iconContainer);
 		}
+	} else {
+		// 检查图标是否需要更新（通过数据属性）
+		const currentType = iconContainer.getAttribute("data-icon-type");
+		const currentIcon = iconContainer.getAttribute("data-icon-name");
+
+		if (
+			currentType === communityPlugin.type &&
+			currentIcon === communityPlugin.icon
+		) {
+			return; // 图标没有变化，跳过更新
+		}
 	}
 
-	// 更新图标（无论是新创建的还是已存在的）
+	// 更新图标（无论是新创建的还是已存在但需要更新的）
 	setIcon(iconContainer, communityPlugin.type, communityPlugin.icon);
+
+	// 保存图标信息到数据属性
+	iconContainer.setAttribute("data-icon-type", communityPlugin.type);
+	iconContainer.setAttribute("data-icon-name", communityPlugin.icon);
 }

--- a/src/util/setIcon.ts
+++ b/src/util/setIcon.ts
@@ -6,6 +6,11 @@ import { getLucideIcon } from "./getLucideIcons";
 
 // 存储已创建的 React root，用于清理
 const rootMap = new WeakMap<HTMLElement, Root>();
+// 存储元素当前的图标信息，用于避免不必要的重新渲染
+const iconStateMap = new WeakMap<
+	HTMLElement,
+	{ type: IconType; icon: string }
+>();
 
 /**
  * 在指定元素中渲染图标
@@ -22,6 +27,18 @@ export default function (
 	icon: string,
 	options?: { append?: boolean }
 ): HTMLElement | void {
+	// 检查图标是否已经是目标图标，如果是则跳过渲染（仅对非 append 模式）
+	if (!options?.append) {
+		const currentState = iconStateMap.get(el);
+		if (
+			currentState &&
+			currentState.type === iconType &&
+			currentState.icon === icon
+		) {
+			return; // 图标没有变化，跳过渲染
+		}
+	}
+
 	// 支持 lucide-react (v0.561.0) 图标
 	if (iconType === "lucide") {
 		const IconComponent = getLucideIcon(icon);
@@ -67,6 +84,9 @@ export default function (
 							className: "lucide-icon",
 						})
 					);
+
+					// 更新图标状态
+					iconStateMap.set(el, { type: iconType, icon });
 				}
 			} catch (error) {
 				console.error(`Error rendering Lucide icon "${icon}":`, error);
@@ -76,6 +96,8 @@ export default function (
 						root.unmount();
 						rootMap.delete(el);
 					}
+					// 清理图标状态
+					iconStateMap.delete(el);
 				}
 			}
 		} else {
@@ -90,5 +112,6 @@ export function cleanupIcon(el: HTMLElement) {
 		existingRoot.unmount();
 		rootMap.delete(el);
 	}
+	iconStateMap.delete(el);
 	el.empty();
 }


### PR DESCRIPTION
在导航项和图标渲染逻辑中加入状态检测与缓存，减少不必要的 DOM/React 更新。
主要改动包括：
- 在 addIconToPluginNavItem 中增加对已有图标数据属性的检查，
  若类型和名称未变化则直接返回，避免重复 setIcon 调用；
  并在更新时把当前图标类型与名称保存到元素的数据属性中。
- 在 setIcon 中新增 iconStateMap（WeakMap）用于记录元素当前的图标
  状态（type 与 icon），在非 append 模式下先比对状态，若相同则跳过渲染。
  渲染成功后更新状态，卸载或清理时删除对应状态。
- 保留并复用已有的 React root 管理逻辑，确保卸载时同步清理状态。

为何这样做：
- 减少不必要的 React 渲染与 DOM 操作，提升性能并避免闪烁或重复工作。
- 通过显式状态记录和数据属性保持元素与状态的一致性，便于后续维护。