### PR TITLE
feat: 优化 Lucide 图标测试与去重提取

### DIFF
--- a/src/util/getLucideIcons.ts
+++ b/src/util/getLucideIcons.ts
@@ -2,41 +2,71 @@ import * as icons from "lucide-react";
 
 /**
  * 获取所有可用的 Lucide 图标名称列表
- * 从 lucide-react 包中提取所有图标组件名称
+ * 从 lucide-react 包中提取所有唯一的图标组件名称
+ *
+ * lucide-react 导出多种格式：
+ * - PascalCase (如 Apple)
+ * - PascalCaseIcon (如 AppleIcon)
+ * - LucidePascalCase (如 LucideApple)
+ *
+ * 我们需要去重，只保留唯一的图标
  */
 export function getLucideIconNames(): string[] {
-	const iconNames: string[] = [];
+	const iconSet = new Set<string>();
+	const excludedKeys = new Set([
+		"default",
+		"createLucideIcon",
+		"icons",
+		"Icon",
+	]);
 
 	for (const key in icons) {
+		// 跳过特殊导出
+		if (excludedKeys.has(key)) {
+			continue;
+		}
+
 		const value = icons[key as keyof typeof icons];
 
-		// lucide-react 导出三种格式：
-		// 1. PascalCase (如 Apple)
-		// 2. PascalCaseIcon (如 AppleIcon)
-		// 3. LucidePascalCase (如 LucideApple)
-		// 我们只使用第一种 PascalCase 格式
+		// 图标组件是对象（React 组件），不是简单的函数
+		// 跳过 undefined 和 null
 		if (
-			key !== "default" &&
-			key !== "createLucideIcon" &&
-			!key.startsWith("Lucide") && // 过滤掉 Lucide 前缀的版本
-			!key.endsWith("Icon") && // 过滤掉 Icon 后缀的版本
-			/^[A-Z]/.test(key) &&
-			value !== undefined
+			!value ||
+			typeof value === "string" ||
+			typeof value === "number" ||
+			typeof value === "boolean"
 		) {
+			continue;
+		}
+
+		// 去除后缀和前缀，提取基础名称
+		let baseName = key;
+
+		// 先去除 "Lucide" 前缀
+		if (baseName.startsWith("Lucide")) {
+			baseName = baseName.slice(6);
+		}
+
+		// 再去除 "Icon" 后缀
+		if (baseName.endsWith("Icon")) {
+			baseName = baseName.slice(0, -4);
+		}
+
+		// 确保是 PascalCase 格式（以大写字母开头且不为空）
+		if (baseName && /^[A-Z]/.test(baseName)) {
 			// 将 PascalCase 转换为 kebab-case
-			const iconName = key
+			const iconName = baseName
 				.replace(/([A-Z])/g, "-$1")
 				.toLowerCase()
 				.slice(1);
 
-			// 过滤掉空字符串
 			if (iconName) {
-				iconNames.push(iconName);
+				iconSet.add(iconName);
 			}
 		}
 	}
 
-	return iconNames.sort();
+	return Array.from(iconSet).sort();
 }
 
 /**

--- a/test/test-lucide-icons.ts
+++ b/test/test-lucide-icons.ts
@@ -1,0 +1,159 @@
+/**
+ * 测试脚本：验证 Lucide 图标获取逻辑
+ *
+ * 用于验证：
+ * 1. 是否正确去重了不同格式的导出（PascalCase, PascalCaseIcon, LucidePascalCase）
+ * 2. 所有图标是否都能被正确提取
+ */
+
+import * as icons from "lucide-react";
+import { getLucideIcon, getLucideIconNames } from "../src/util/getLucideIcons";
+
+// 分析 lucide-react 的所有导出
+function analyzeLucideExports() {
+	const allKeys: string[] = [];
+	const specialKeys: string[] = [];
+	const iconKeys: string[] = [];
+	const lucideKeys: string[] = [];
+	const baseKeys: string[] = [];
+	const functionKeys: string[] = [];
+
+	for (const key in icons) {
+		allKeys.push(key);
+		const value = icons[key as keyof typeof icons];
+
+		if (typeof value === "function") {
+			functionKeys.push(key);
+		}
+
+		if (
+			key === "default" ||
+			key === "createLucideIcon" ||
+			key === "icons"
+		) {
+			specialKeys.push(key);
+		} else if (key.startsWith("Lucide")) {
+			lucideKeys.push(key);
+		} else if (key.endsWith("Icon")) {
+			iconKeys.push(key);
+		} else if (/^[A-Z]/.test(key)) {
+			baseKeys.push(key);
+		}
+	}
+
+	console.log("=== Lucide 导出分析 ===");
+	console.log(`总导出数量: ${allKeys.length}`);
+	console.log(`函数类型: ${functionKeys.length}`);
+	console.log(`特殊键: ${specialKeys.length} (${specialKeys.join(", ")})`);
+	console.log(`以 Lucide 开头: ${lucideKeys.length}`);
+	console.log(`以 Icon 结尾: ${iconKeys.length}`);
+	console.log(`基础 PascalCase: ${baseKeys.length}`);
+
+	// 检查前几个函数键
+	console.log(`前5个函数键: ${functionKeys.slice(0, 5).join(", ")}`);
+	console.log();
+
+	// 示例：显示某些图标的不同格式
+	console.log("=== 示例：不同导出格式 ===");
+	const exampleIcon = "Activity";
+	const formats = [exampleIcon, `${exampleIcon}Icon`, `Lucide${exampleIcon}`];
+
+	formats.forEach((format) => {
+		const exists = format in icons;
+		const value = icons[format as keyof typeof icons];
+		const isFunction = typeof value === "function";
+		console.log(
+			`${format}: ${exists ? "✓" : "✗"} (函数: ${isFunction ? "✓" : "✗"})`
+		);
+	});
+	console.log();
+}
+
+// 测试我们的图标提取函数
+function testGetLucideIconNames() {
+	console.log("=== 测试 getLucideIconNames() ===");
+
+	// 手动测试处理逻辑
+	console.log("测试名称处理逻辑:");
+	const testKeys = [
+		"Activity",
+		"ActivityIcon",
+		"LucideActivity",
+		"Icon",
+		"default",
+		"createLucideIcon",
+	];
+
+	testKeys.forEach((key) => {
+		let baseName = key;
+
+		// 先去除 "Lucide" 前缀
+		if (baseName.startsWith("Lucide")) {
+			baseName = baseName.slice(6);
+		}
+
+		// 再去除 "Icon" 后缀
+		if (baseName.endsWith("Icon")) {
+			baseName = baseName.slice(0, -4);
+		}
+
+		const isValid = baseName && /^[A-Z]/.test(baseName);
+		const iconName = isValid
+			? baseName
+					.replace(/([A-Z])/g, "-$1")
+					.toLowerCase()
+					.slice(1)
+			: "";
+
+		console.log(
+			`  ${key} -> baseName: "${baseName}", valid: ${isValid}, iconName: "${iconName}"`
+		);
+	});
+	console.log();
+
+	const iconNames = getLucideIconNames();
+	console.log(`提取的唯一图标数量: ${iconNames.length}`);
+	console.log(`前10个图标: ${iconNames.slice(0, 10).join(", ")}`);
+	console.log();
+
+	// 验证几个已知图标
+	const testIcons = ["activity", "apple", "arrow-right", "check", "x"];
+	console.log("验证已知图标:");
+	testIcons.forEach((iconName) => {
+		const exists = iconNames.includes(iconName);
+		const component = getLucideIcon(iconName);
+		console.log(
+			`  ${iconName}: ${exists ? "✓" : "✗"} (组件: ${
+				component ? "✓" : "✗"
+			})`
+		);
+	});
+	console.log();
+}
+
+// 主测试函数
+function runTests() {
+	console.log("开始测试 Lucide 图标提取...\n");
+
+	analyzeLucideExports();
+	testGetLucideIconNames();
+
+	// 验证数量
+	console.log("=== 验证去重效果 ===");
+	const iconNames = getLucideIconNames();
+	const totalExports = Object.keys(icons).length - 3; // 减去 default, createLucideIcon, icons
+	console.log(`总导出数（不含特殊键）: ${totalExports}`);
+	console.log(`唯一图标数: ${iconNames.length}`);
+	console.log(`理论上每个图标有3个导出，去重后应该是: ${totalExports / 3}`);
+	console.log(`实际唯一图标数: ${iconNames.length}`);
+	console.log(
+		`匹配: ${
+			Math.abs(iconNames.length - totalExports / 3) < 10 ? "✓" : "✗"
+		}`
+	);
+	console.log();
+
+	console.log("测试完成!");
+}
+
+runTests();


### PR DESCRIPTION
新增和修改测试及工具函数，验证并稳健化从 lucide-react
中提取唯一图标名称的逻辑，主要改动包括：

- 新增完整的测试脚本 test/test-lucide-icons.ts：
  - 分析 lucide-react 的所有导出，统计不同类型（函数、
    PascalCase、以 Icon 结尾、以 Lucide 开头等）。
  - 演示并验证不同导出格式（Activity、ActivityIcon、
    LucideActivity）的去重与识别逻辑。
  - 调用 getLucideIconNames 和 getLucideIcon 来验证若干已知
    图标是否能被正确提取并映射为组件。
  - 输出去重前后的数量对比，帮助检测提取逻辑是否符合
    预期。

- 修改 src/util/getLucideIcons.ts：
  - 使用 Set 收集唯一图标名称并显式排除特殊导出（default、
    createLucideIcon、icons、Icon），避免将非图标项计入。
  - 添加注释说明 lucide-react 的多种导出格式（PascalCase、
    PascalCaseIcon、LucidePascalCase）及去重目的。
  - 强化过滤条件，跳过 undefined/null 与非图标导出，提升
    提取结果的准确性与稳定性。

为什么这样改：
- lucide-react 对每个图标存在多种命名导出，直接枚举会产
  生重复项。新增去重逻辑和测试可以确保只保留唯一的基
  本图标名称，防止上层使用重复名称或统计错误。
- 测试脚本通过输出和示例验证，便于本地手动检查与日后
  调试导出变化，降低集成时出现遗漏或误判的风险。