### PR TITLE
chore: remove conventional-changelog related deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
 				"@typescript-eslint/eslint-plugin": "8.49.0",
 				"@typescript-eslint/parser": "^8.49.0",
 				"builtin-modules": "5.0.0",
-				"conventional-changelog-cli": "^5.0.0",
 				"esbuild": "0.27.1",
 				"eslint": "^9.39.2",
 				"eslint-plugin-obsidianmd": "^0.1.9",
@@ -711,32 +710,6 @@
 				"crelt": "^1.0.6",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
-			}
-		},
-		"node_modules/@conventional-changelog/git-client": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmmirror.com/@conventional-changelog/git-client/-/git-client-1.0.1.tgz",
-			"integrity": "sha512-PJEqBwAleffCMETaVm/fUgHldzBE35JFk3/9LL6NUA5EXa3qednu+UT6M7E5iBu3zIQZCULYIiZ90fBYHt6xUw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/semver": "^7.5.5",
-				"semver": "^7.5.2"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"conventional-commits-filter": "^5.0.0",
-				"conventional-commits-parser": "^6.0.0"
-			},
-			"peerDependenciesMeta": {
-				"conventional-commits-filter": {
-					"optional": true
-				},
-				"conventional-commits-parser": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@csstools/selector-resolve-nested": {
@@ -1646,16 +1619,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/nzakas"
-			}
-		},
-		"node_modules/@hutson/parse-repository-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmmirror.com/@hutson/parse-repository-url/-/parse-repository-url-5.0.0.tgz",
-			"integrity": "sha512-e5+YUKENATs1JgYHMzTr2MW/NDcXGfYFAuOQU8gJgF/kEh4EqKgfGrfLI67bMD4tbhZVlkigz/9YYwWcbOFthg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/@iconify/types": {
@@ -5051,13 +5014,6 @@
 				"undici-types": "~7.16.0"
 			}
 		},
-		"node_modules/@types/normalize-package-data": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmmirror.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/offscreencanvas": {
 			"version": "2019.7.3",
 			"resolved": "https://registry.npmmirror.com/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
@@ -5101,13 +5057,6 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
-		},
-		"node_modules/@types/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmmirror.com/@types/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.3",
@@ -5707,13 +5656,6 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/add-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmmirror.com/add-stream/-/add-stream-1.0.0.tgz",
-			"integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmmirror.com/ajv/-/ajv-6.12.6.tgz",
@@ -5825,13 +5767,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/array-ify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmmirror.com/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/array-includes": {
 			"version": "3.1.9",
@@ -6597,17 +6532,6 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/compare-func": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmmirror.com/compare-func/-/compare-func-2.0.0.tgz",
-			"integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"array-ify": "^1.0.0",
-				"dot-prop": "^5.1.0"
-			}
-		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmmirror.com/concat-map/-/concat-map-0.0.1.tgz",
@@ -6621,224 +6545,6 @@
 			"integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/conventional-changelog": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog/-/conventional-changelog-6.0.0.tgz",
-			"integrity": "sha512-tuUH8H/19VjtD9Ig7l6TQRh+Z0Yt0NZ6w/cCkkyzUbGQTnUEmKfGtkC9gGfVgCfOL1Rzno5NgNF4KY8vR+Jo3w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"conventional-changelog-angular": "^8.0.0",
-				"conventional-changelog-atom": "^5.0.0",
-				"conventional-changelog-codemirror": "^5.0.0",
-				"conventional-changelog-conventionalcommits": "^8.0.0",
-				"conventional-changelog-core": "^8.0.0",
-				"conventional-changelog-ember": "^5.0.0",
-				"conventional-changelog-eslint": "^6.0.0",
-				"conventional-changelog-express": "^5.0.0",
-				"conventional-changelog-jquery": "^6.0.0",
-				"conventional-changelog-jshint": "^5.0.0",
-				"conventional-changelog-preset-loader": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-changelog-angular": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-angular/-/conventional-changelog-angular-8.1.0.tgz",
-			"integrity": "sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"compare-func": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-changelog-atom": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-atom/-/conventional-changelog-atom-5.0.0.tgz",
-			"integrity": "sha512-WfzCaAvSCFPkznnLgLnfacRAzjgqjLUjvf3MftfsJzQdDICqkOOpcMtdJF3wTerxSpv2IAAjX8doM3Vozqle3g==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-changelog-cli": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-cli/-/conventional-changelog-cli-5.0.0.tgz",
-			"integrity": "sha512-9Y8fucJe18/6ef6ZlyIlT2YQUbczvoQZZuYmDLaGvcSBP+M6h+LAvf7ON7waRxKJemcCII8Yqu5/8HEfskTxJQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"add-stream": "^1.0.0",
-				"conventional-changelog": "^6.0.0",
-				"meow": "^13.0.0",
-				"tempfile": "^5.0.0"
-			},
-			"bin": {
-				"conventional-changelog": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-changelog-codemirror": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-codemirror/-/conventional-changelog-codemirror-5.0.0.tgz",
-			"integrity": "sha512-8gsBDI5Y3vrKUCxN6Ue8xr6occZ5nsDEc4C7jO/EovFGozx8uttCAyfhRrvoUAWi2WMm3OmYs+0mPJU7kQdYWQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-changelog-conventionalcommits": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
-			"integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"compare-func": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-changelog-core": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-core/-/conventional-changelog-core-8.0.0.tgz",
-			"integrity": "sha512-EATUx5y9xewpEe10UEGNpbSHRC6cVZgO+hXQjofMqpy+gFIrcGvH3Fl6yk2VFKh7m+ffenup2N7SZJYpyD9evw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@hutson/parse-repository-url": "^5.0.0",
-				"add-stream": "^1.0.0",
-				"conventional-changelog-writer": "^8.0.0",
-				"conventional-commits-parser": "^6.0.0",
-				"git-raw-commits": "^5.0.0",
-				"git-semver-tags": "^8.0.0",
-				"hosted-git-info": "^7.0.0",
-				"normalize-package-data": "^6.0.0",
-				"read-package-up": "^11.0.0",
-				"read-pkg": "^9.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-changelog-ember": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-ember/-/conventional-changelog-ember-5.0.0.tgz",
-			"integrity": "sha512-RPflVfm5s4cSO33GH/Ey26oxhiC67akcxSKL8CLRT3kQX2W3dbE19sSOM56iFqUJYEwv9mD9r6k79weWe1urfg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-changelog-eslint": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-eslint/-/conventional-changelog-eslint-6.0.0.tgz",
-			"integrity": "sha512-eiUyULWjzq+ybPjXwU6NNRflApDWlPEQEHvI8UAItYW/h22RKkMnOAtfCZxMmrcMO1OKUWtcf2MxKYMWe9zJuw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-changelog-express": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-express/-/conventional-changelog-express-5.0.0.tgz",
-			"integrity": "sha512-D8Q6WctPkQpvr2HNCCmwU5GkX22BVHM0r4EW8vN0230TSyS/d6VQJDAxGb84lbg0dFjpO22MwmsikKL++Oo/oQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-changelog-jquery": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-jquery/-/conventional-changelog-jquery-6.0.0.tgz",
-			"integrity": "sha512-2kxmVakyehgyrho2ZHBi90v4AHswkGzHuTaoH40bmeNqUt20yEkDOSpw8HlPBfvEQBwGtbE+5HpRwzj6ac2UfA==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-changelog-jshint": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-jshint/-/conventional-changelog-jshint-5.0.0.tgz",
-			"integrity": "sha512-gGNphSb/opc76n2eWaO6ma4/Wqu3tpa2w7i9WYqI6Cs2fncDSI2/ihOfMvXveeTTeld0oFvwMVNV+IYQIk3F3g==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"compare-func": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-changelog-preset-loader": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
-			"integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-changelog-writer": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-writer/-/conventional-changelog-writer-8.2.0.tgz",
-			"integrity": "sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"conventional-commits-filter": "^5.0.0",
-				"handlebars": "^4.7.7",
-				"meow": "^13.0.0",
-				"semver": "^7.5.2"
-			},
-			"bin": {
-				"conventional-changelog-writer": "dist/cli/index.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-commits-filter": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmmirror.com/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-			"integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/conventional-commits-parser": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmmirror.com/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
-			"integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"meow": "^13.0.0"
-			},
-			"bin": {
-				"conventional-commits-parser": "dist/cli/index.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
 		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
@@ -7681,19 +7387,6 @@
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
-			}
-		},
-		"node_modules/dot-prop": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmmirror.com/dot-prop/-/dot-prop-5.3.0.tgz",
-			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-obj": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/dotenv": {
@@ -9039,19 +8732,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/find-up-simple": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmmirror.com/find-up-simple/-/find-up-simple-1.0.1.tgz",
-			"integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/flat-cache": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmmirror.com/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -9316,40 +8996,6 @@
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
-		"node_modules/git-raw-commits": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmmirror.com/git-raw-commits/-/git-raw-commits-5.0.0.tgz",
-			"integrity": "sha512-I2ZXrXeOc0KrCvC7swqtIFXFN+rbjnC7b2T943tvemIOVNl+XP8YnA9UVwqFhzzLClnSA60KR/qEjLpXzs73Qg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@conventional-changelog/git-client": "^1.0.0",
-				"meow": "^13.0.0"
-			},
-			"bin": {
-				"git-raw-commits": "src/cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/git-semver-tags": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmmirror.com/git-semver-tags/-/git-semver-tags-8.0.0.tgz",
-			"integrity": "sha512-N7YRIklvPH3wYWAR2vysaqGLPRcpwQ0GKdlqTiVN5w1UmCdaeY3K8s6DMKRCh54DDdzyt/OAB6C8jgVtb7Y2Fg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@conventional-changelog/git-client": "^1.0.0",
-				"meow": "^13.0.0"
-			},
-			"bin": {
-				"git-semver-tags": "src/cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/glob": {
 			"version": "10.5.0",
 			"resolved": "https://registry.npmmirror.com/glob/-/glob-10.5.0.tgz",
@@ -9602,19 +9248,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^10.0.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmmirror.com/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -9753,19 +9386,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.19"
-			}
-		},
-		"node_modules/index-to-position": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmmirror.com/index-to-position/-/index-to-position-1.2.0.tgz",
-			"integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/inflight": {
@@ -10084,16 +9704,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-obj": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmmirror.com/is-obj/-/is-obj-2.0.0.tgz",
-			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/is-regex": {
@@ -11453,19 +11063,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/meow": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmmirror.com/meow/-/meow-13.2.0.tgz",
-			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmmirror.com/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -11690,21 +11287,6 @@
 			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/normalize-package-data": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmmirror.com/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -12774,88 +12356,6 @@
 				}
 			}
 		},
-		"node_modules/read-package-up": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmmirror.com/read-package-up/-/read-package-up-11.0.0.tgz",
-			"integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-up-simple": "^1.0.0",
-				"read-pkg": "^9.0.0",
-				"type-fest": "^4.6.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-package-up/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmmirror.com/read-pkg/-/read-pkg-9.0.1.tgz",
-			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/normalize-package-data": "^2.4.3",
-				"normalize-package-data": "^6.0.0",
-				"parse-json": "^8.0.0",
-				"type-fest": "^4.6.0",
-				"unicorn-magic": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg/node_modules/parse-json": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmmirror.com/parse-json/-/parse-json-8.3.0.tgz",
-			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.26.2",
-				"index-to-position": "^1.1.0",
-				"type-fest": "^4.39.1"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmmirror.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -13430,42 +12930,6 @@
 				"source-map": "^0.6.0"
 			}
 		},
-		"node_modules/spdx-correct": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmmirror.com/spdx-correct/-/spdx-correct-3.2.0.tgz",
-			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"node_modules/spdx-exceptions": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmmirror.com/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-			"dev": true,
-			"license": "CC-BY-3.0"
-		},
-		"node_modules/spdx-expression-parse": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmmirror.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"node_modules/spdx-license-ids": {
-			"version": "3.0.22",
-			"resolved": "https://registry.npmmirror.com/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-			"integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
-			"dev": true,
-			"license": "CC0-1.0"
-		},
 		"node_modules/sprintf-js": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmmirror.com/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -13878,32 +13342,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
-			}
-		},
-		"node_modules/temp-dir": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmmirror.com/temp-dir/-/temp-dir-3.0.0.tgz",
-			"integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.16"
-			}
-		},
-		"node_modules/tempfile": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmmirror.com/tempfile/-/tempfile-5.0.0.tgz",
-			"integrity": "sha512-bX655WZI/F7EoTDw9JvQURqAXiPHi8o8+yFxPF2lWYyz1aHnmMRuXWqL6YB6GmeO0o4DIYWHLgGNi/X64T+X4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"temp-dir": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=14.18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/test-exclude": {
@@ -14405,19 +13843,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/unicorn-magic": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmmirror.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/universalify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
@@ -14611,17 +14036,6 @@
 			},
 			"engines": {
 				"node": ">=10.12.0"
-			}
-		},
-		"node_modules/validate-npm-package-license": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmmirror.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"node_modules/vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
 		"@typescript-eslint/eslint-plugin": "8.49.0",
 		"@typescript-eslint/parser": "^8.49.0",
 		"builtin-modules": "5.0.0",
-		"conventional-changelog-cli": "^5.0.0",
 		"esbuild": "0.27.1",
 		"eslint": "^9.39.2",
 		"eslint-plugin-obsidianmd": "^0.1.9",


### PR DESCRIPTION
从 package.json 和 package-lock.json 中移除对 conventional-changelog-cli
及其包的依赖锁定信息。这样做是为了清理不再使用的开发依赖，
减小锁文件体积并避免不必要的安装与维护开销。主要改动包括删除
package.json 中的依赖条目以及 lock 文件中大量与 conventional-
changelog 及其子包相关的节点条目。