### PR TITLE
chore: 修改 FUNDING

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,17 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+# ko_fi: # Replace with a single Ko-fi username
+ko_fi: ravenhogwarts
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+# custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
 custom: ["https://afdian.com/a/ravenhogwarts"]


### PR DESCRIPTION
在仓库中新增 .github/FUNDING.yml 文件，配置多个开源资助平台选项
并为 ko_fi 和 custom 填入作者相关的资助链接。这样做是为了让项目在
GitHub 页面上显示可用的赞助途径，便于用户快速找到支持项目的方式，
提升社区资助可见性并简化维护者收款流程。