### PR TITLE
refactor(icon): 统一 SVG 图标的 class 名称

### DIFF
--- a/src/util/setIcon.ts
+++ b/src/util/setIcon.ts
@@ -81,7 +81,7 @@ export default function (
 						React.createElement(IconComponent, {
 							size: 16,
 							strokeWidth: 2,
-							className: "lucide-icon",
+							className: "svg-icon",
 						})
 					);
 


### PR DESCRIPTION
将生成图标时的 className 从 "lucide-icon" 修改为
"svg-icon"。主要用于标准化样式类名，避免与第三方库
的命名冲突，并便于全局样式统一管理和替换图标库时
保持兼容。