### PR TITLE
feat: 调整国际化配置基础语言设置

### DIFF
--- a/.typesafe-i18n.json
+++ b/.typesafe-i18n.json
@@ -1,5 +1,5 @@
 {
-   "adapter": "react",
-   "baseLocale": "zh",
-   "$schema": "https://unpkg.com/typesafe-i18n@5.27.1/schema/typesafe-i18n.json"
+	"adapter": "react",
+	"baseLocale": "en",
+	"$schema": "https://unpkg.com/typesafe-i18n@5.27.1/schema/typesafe-i18n.json"
 }


### PR DESCRIPTION
修改 .typesafe-i18n.json 配置文件，将基础语言从中文
(zh) 更改为英文 (en)，以适应项目的国际化需求。
同时统一文件的缩进格式，提高代码的一致性和可读性。